### PR TITLE
Remove error handler from old socket before closing.

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -332,6 +332,7 @@ Strophe.Websocket.prototype = {
      */
     _closeSocket: function () {
         if (this.socket) { try {
+            this.socket.onerror = null;
             this.socket.close();
         } catch (e) {} }
         this.socket = null;


### PR DESCRIPTION
_closeSocket was not detaching the error handler from the socket before closing which could lead any subsequent errors to pull down a new connection on a new socket.